### PR TITLE
🎨Update: 팔로우 기능 - 유저 본인 팔로우 금지 #9

### DIFF
--- a/users/models.py
+++ b/users/models.py
@@ -34,7 +34,7 @@ class User(AbstractBaseUser):
         max_length=20,
         unique=True,
     )
-    email = models.EmailField(max_length=255, unique=True, default='', blank=True)
+    email = models.EmailField(max_length=255, default='', blank=True)
     profile_img = models.ImageField(default='', blank=True)
     bio = models.CharField(max_length=255, default='', blank=True)
     followings = models.ManyToManyField('self', symmetrical=False, related_name='followers', blank=True)

--- a/users/views.py
+++ b/users/views.py
@@ -82,12 +82,15 @@ class FollowView(APIView):
     def post(self, request, user_id):
         you = get_object_or_404(User, id=user_id)
         me = request.user
-        if me in you.followers.all():
-            you.followers.remove(me)
-            return Response("Unfollow", status=status.HTTP_200_OK)
-        else:
-            you.followers.add(me)
-            return Response("Follow", status=status.HTTP_200_OK)
+        if me != you:
+            if me in you.followers.all():
+                you.followers.remove(me)
+                return Response("Unfollow", status=status.HTTP_200_OK)
+            else:
+                you.followers.add(me)
+                return Response("Follow", status=status.HTTP_200_OK)
+        else: # 본인을 팔로우 하려고 하면 팔로우 동작을 하지 않고 메시지를 띄웁니다.
+            return Response("본인을 팔로우할 수 없습니다.", status=status.HTTP_400_BAD_REQUEST)
 
 
 class UserRecommendView(APIView):


### PR DESCRIPTION
유저 본인이 본인을 팔로우 할 수 있던 것을 수정했습니다.
본인을 팔로우하려고 하면 팔로우 동작을 하지 않고 "본인을 팔로우할 수 없습니다"라는 메시지를 띄웁니다.